### PR TITLE
:fireworks: populate initial dashboard state with `initialstate` query parameter

### DIFF
--- a/dashboardsly/src/js/actions/AppActions.js
+++ b/dashboardsly/src/js/actions/AppActions.js
@@ -112,6 +112,8 @@ var AppActions = {
     initialize: function() {
         console.warn('initialize');
 
+        // Check for initial state in a JSON-ified, URL-encoded query parameter `initialstate`
+        // If it exists, then set the store to this state
         let initialState = getParameterByName('initialstate');
         if(initialState !== '') {
             initialState = JSON.parse(initialState);

--- a/dashboardsly/src/js/actions/AppActions.js
+++ b/dashboardsly/src/js/actions/AppActions.js
@@ -3,6 +3,7 @@
 import AppConstants from '../constants/AppConstants';
 import AppDispatcher from '../dispatchers/AppDispatcher';
 import {AppStore} from '../stores/AppStore';
+import getParameterByName from '../utils/utils';
 
 import request from 'request';
 
@@ -110,9 +111,20 @@ var AppActions = {
 
     initialize: function() {
         console.warn('initialize');
-        let username = AppStore.getState().username;
-        let page = AppStore.getState().page;
-        let apikey = AppStore.getState().apikey;
+
+        let initialState = getParameterByName('initialstate');
+        if(initialState !== '') {
+            initialState = JSON.parse(initialState);
+            const validInitialStoreKeys = [
+                'username', 'rows', 'banner'
+            ];
+            validInitialStoreKeys.forEach((v, i) => {
+                if(v in initialState) {
+                    AppActions.updateKey(v, initialState[v]);
+                }
+            });
+        }
+
         if(ENV.mode==='create') {
             if(pendingRequest) {
                 pendingRequest.abort();
@@ -128,6 +140,9 @@ var AppActions = {
                 value: false
             });
 
+            const username = AppStore.getState().username;
+            const page = AppStore.getState().page;
+            const apikey = AppStore.getState().apikey;
             var url = location.protocol + '//' + window.location.host + '/files?username='+username+'&page='+page+'&apikey='+apikey;
             console.warn(url);
             pendingRequest = request({

--- a/dashboardsly/src/js/actions/AppActions.js
+++ b/dashboardsly/src/js/actions/AppActions.js
@@ -109,9 +109,7 @@ var AppActions = {
 
     },
 
-    initialize: function() {
-        console.warn('initialize');
-
+    loadInitialState: function() {
         // Check for initial state in a JSON-ified, URL-encoded query parameter `initialstate`
         // If it exists, then set the store to this state
         let initialState = getParameterByName('initialstate');
@@ -126,6 +124,10 @@ var AppActions = {
                 }
             });
         }
+    },
+
+    initialize: function() {
+        console.warn('initialize');
 
         if(ENV.mode==='create') {
             if(pendingRequest) {

--- a/dashboardsly/src/js/stores/AppStore.js
+++ b/dashboardsly/src/js/stores/AppStore.js
@@ -188,5 +188,6 @@ AppDispatcher.register(actions);
 exports.AppStore = AppStore;
 
 (function(){
+    AppActions.loadInitialState();
     AppActions.initialize();
 })();

--- a/dashboardsly/src/js/utils/utils.js
+++ b/dashboardsly/src/js/utils/utils.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function getParameterByName(name) {
+    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+        results = regex.exec(location.search);
+    return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
+
+module.exports = getParameterByName


### PR DESCRIPTION
cc react kidz: @bpostlethwaite @alexander-daniel 

usage: https://tonicdev.com/chriddyp/565dd6db21c6e60c00b123fc

```javascript
var initialState = {
    "rows": [
        // first row
        [{"plot_url": "https://plot.ly/~benji.b/38"},
         {"plot_url": "https://plot.ly/~benji.b/54"}],
        
        // second row
        [{"plot_url": "https://plot.ly/~benji.b/62"}]
    ],
    "banner": {
        "visible": true,
        "backgroundcolor": "#3d4a57",
        "textcolor": "white",
        "title": "quarterly outlook",
        "links": [
            {"href": "", "text": "sales"},
            {"href": "", "text": "growth"},
            {"href": "", "text": "exports"}
        ]
    },
    "username": "chriddyp"
}

console.warn('http://dashboards.ly/create?initialstate='+encodeURIComponent(JSON.stringify(initialState)))
```