### PR TITLE
On-Prem auth fixes

### DIFF
--- a/dashboardsly/__init__.py
+++ b/dashboardsly/__init__.py
@@ -12,7 +12,11 @@ else:
     # development on localhost
     app.config.from_object('dashboardsly.config.DevelopmentConfig')
 
-app.config['DEFAULT_USERNAME'] = 'benji.b'
-app.config['DEFAULT_APIKEY'] = 'op16fm0vke'
+if app.config['PLOTLY_ON_PREM']:
+    app.config['DEFAULT_USERNAME'] = None
+    app.config['DEFAULT_APIKEY'] = None
+else:
+    app.config['DEFAULT_USERNAME'] = 'benji.b'
+    app.config['DEFAULT_APIKEY'] = 'op16fm0vke'
 
 import dashboardsly.views

--- a/dashboardsly/src/js/actions/AppActions.js
+++ b/dashboardsly/src/js/actions/AppActions.js
@@ -147,7 +147,7 @@ var AppActions = {
             const username = AppStore.getState().username;
             const page = AppStore.getState().page;
             const apikey = AppStore.getState().apikey;
-            var url = location.protocol + '//' + window.location.host + CONFIG.ROOT_PATH + 'files?username='+username+'&page='+page+'&apikey='+apikey;
+            var url = location.protocol + '//' + window.location.host + CONFIG.ROOT_PATH + '/files?username='+username+'&page='+page+'&apikey='+apikey;
             console.warn(url);
             pendingRequest = request({
                 method: 'GET',
@@ -202,7 +202,7 @@ var AppActions = {
 
             request({
                 method: 'GET',
-                url: location.origin + CONFIG.ROOT_PATH + 'dashboard?id='+dashboard_id
+                url: location.origin + CONFIG.ROOT_PATH + '/dashboard?id='+dashboard_id
             }, function(err, res, body) {
                 if(!err && res.statusCode == 200) {
                     let content = JSON.parse(body).content;

--- a/dashboardsly/src/js/stores/AppStore.js
+++ b/dashboardsly/src/js/stores/AppStore.js
@@ -8,8 +8,8 @@ import AppActions from '../actions/AppActions';
 var _appStore = {
     requestIsPending: false,
     page: 0,
-    username: 'benji.b',
-    apikey: 'op16fm0vke',
+    username: CONFIG.DEFAULT_USERNAME,
+    apikey: CONFIG.DEFAULT_APIKEY,
     plots: [],
     canRearrange: false,
     requests: [],

--- a/dashboardsly/views.py
+++ b/dashboardsly/views.py
@@ -53,10 +53,12 @@ auth = HTTPBasicAuth()
 
 @app.context_processor
 def frontend_config():
+    # "config" variables are available in the frontend from the global CONFIG
     config = {
         'PLOTLY_DOMAIN': app.config['PLOTLY_DOMAIN'],
         'ROOT_PATH': request.script_root or '/',
     }
+    # Other variables end up in the page's context, for templates
     return {
         'CONFIG': config,
         'USE_CONTENT_DELIVERY_NETWORKS':

--- a/dashboardsly/views.py
+++ b/dashboardsly/views.py
@@ -57,6 +57,8 @@ def frontend_config():
     config = {
         'PLOTLY_DOMAIN': app.config['PLOTLY_DOMAIN'],
         'ROOT_PATH': request.script_root,
+        'DEFAULT_USERNAME': app.config['DEFAULT_USERNAME'],
+        'DEFAULT_APIKEY': app.config['DEFAULT_APIKEY'],
     }
     # Other variables end up in the page's context, for templates
     return {

--- a/dashboardsly/views.py
+++ b/dashboardsly/views.py
@@ -166,14 +166,11 @@ def files(username, apikey, page):
                '&filetype=grid&filetype=plot'
                '&order_by=-date_modified'
                '').format(app.config['PLOTLY_API_DOMAIN'], page, username)
+        kwargs = {}
         if authenticated:
-            auth = requests.auth.HTTPBasicAuth(username, apikey)
-        else:
-            auth = requests.auth.HTTPBasicAuth(
-                app.config['DEFAULT_USERNAME'],
-                app.config['DEFAULT_APIKEY'])
-        r = requests.get(url, auth=auth, headers={
-            'plotly-client-platform': 'dashboardsly'})
+            kwargs['auth'] = requests.auth.HTTPBasicAuth(username, apikey)
+        r = requests.get(url, headers={
+            'plotly-client-platform': 'dashboardsly'}, **kwargs)
         try:
             r.raise_for_status()
         except requests.exceptions.HTTPError as e:

--- a/dashboardsly/views.py
+++ b/dashboardsly/views.py
@@ -235,8 +235,9 @@ def get_files():
     page = int(request.args.get('page', 0))
     apikey = request.args.get('apikey', app.config['DEFAULT_APIKEY'])
 
-    # cache benji.b's files
-    if username == app.config['DEFAULT_USERNAME'] and page == 0:
+    # Use cached files for benji.b, Non-Prem
+    if (username == app.config['DEFAULT_USERNAME'] and page == 0 and
+        not app.config['PLOTLY_ON_PREM']):
         plots = default_plots.plots
         is_last = False
         is_authenticated = apikey == app.config['DEFAULT_APIKEY']

--- a/dashboardsly/views.py
+++ b/dashboardsly/views.py
@@ -56,7 +56,7 @@ def frontend_config():
     # "config" variables are available in the frontend from the global CONFIG
     config = {
         'PLOTLY_DOMAIN': app.config['PLOTLY_DOMAIN'],
-        'ROOT_PATH': request.script_root or '/',
+        'ROOT_PATH': request.script_root,
     }
     # Other variables end up in the page's context, for templates
     return {


### PR DESCRIPTION
Fix auth for On-Prem:
* Disable `benji.b` functionality.
* If the user is unauthenticated, just make an unauthenticated `/folders/all` request.

The latter needs a change to streambed (including prod), so this should *not* be deployed yet.

* [x] Test streambed change on stage
* [x] Merge & deploy streambed change
* [x] Test this PR on Heroku